### PR TITLE
Fixing mount point for mysql data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - '3306:3306'
     volumes:
-      - './zabbix/mysql:/var/lib/data'
+      - './zabbix/mysql:/var/lib/mysql'
     environment:
       - MYSQL_ROOT_PASSWORD=carryontech
       - MYSQL_DATABASE=zabbix


### PR DESCRIPTION
The mount point for mysql was /var/lib/data which wasn't used and caused the data to be re-initialized each time the container was recrerated. Changing it to /var/lib/mysql allows for data to be saved in the correct place.